### PR TITLE
Use overlay2 docker storage driver

### DIFF
--- a/pkg/generator/templates/cloud-init.ubuntu-ali.template
+++ b/pkg/generator/templates/cloud-init.ubuntu-ali.template
@@ -18,7 +18,7 @@ mount -a
 
 #Fix mis-configuration of dockerd
 mkdir -p /etc/docker
-echo '{ "storage-driver": "devicemapper" }' > /etc/docker/daemon.json
+echo '{ "storage-driver": "overlay2" }' > /etc/docker/daemon.json
 sed -i '/Environment=DOCKER_SELINUX=--selinux-enabled=true/s/^/#/g' /run/systemd/system/docker.service
 {{- end }}
 

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -10,7 +10,7 @@ mount -a
 
 #Fix mis-configuration of dockerd
 mkdir -p /etc/docker
-echo '{ "storage-driver": "devicemapper" }' > /etc/docker/daemon.json
+echo '{ "storage-driver": "overlay2" }' > /etc/docker/daemon.json
 sed -i '/Environment=DOCKER_SELINUX=--selinux-enabled=true/s/^/#/g' /run/systemd/system/docker.service
 
 mkdir -p '/'


### PR DESCRIPTION
**What this PR does / why we need it**:
Change docker storage driver from devicemapper to overlay2.

**Which issue(s) this PR fixes**:
Fixes #2
